### PR TITLE
Fix arguments' order for google analytics tracking method.

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -28,7 +28,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-          ga('send', 'event', name, options && options.value);
+          ga('send', 'event', name, options && options.action, options && options.label, options && options.value);
         JS
       end
 


### PR DESCRIPTION
As per documentation in https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview

Tested only in local, didn't check the Google Analytics seedrs report (no access). My GA didn't allow to see the value of events in the Real-time section.
