### PR TITLE
Disable robot checking

### DIFF
--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -42,9 +42,11 @@ module Analytical
         if options[:disable_if] && options[:disable_if].call(self)
           options[:modules] = []
         end
-        if analytical_is_robot?(request.user_agent)
-          options[:modules] = []
-        end
+        # Don't check for robots, robots can cause a page to be cached. And that cached page will be used by normal
+        # users with analytical disabled.
+        # if analytical_is_robot?(request.user_agent)
+        #   options[:modules] = []
+        # end
         options[:modules] = options[:filter_modules].call(self, options[:modules]) if options[:filter_modules]
         Analytical::Api.new options
       end

--- a/spec/analytical_spec.rb
+++ b/spec/analytical_spec.rb
@@ -52,14 +52,14 @@ describe "Analytical" do
       end
     end
 
-    describe 'with a robot request' do
-      it 'should set the modules to []' do
-        DummyForInit.analytical
-        d = DummyForInit.new
-        d.stub!(:'analytical_is_robot?').and_return(true)
-        d.analytical.options[:modules].should == []
-      end
-    end
+    # describe 'with a robot request' do
+    #   it 'should set the modules to []' do
+    #     DummyForInit.analytical
+    #     d = DummyForInit.new
+    #     d.stub!(:'analytical_is_robot?').and_return(true)
+    #     d.analytical.options[:modules].should == []
+    #   end
+    # end
 
     it 'should open the initialization file' do
       File.should_receive(:'exists?').with("#{Rails.root}/config/analytical.yml").and_return(true)


### PR DESCRIPTION
Robots can cause a page to be cached. And that cached page will be used by normal users with analytical disabled.