### PR TITLE
Configure track option for use in google module

### DIFF
--- a/app/views/application/_analytical_javascript.html.erb
+++ b/app/views/application/_analytical_javascript.html.erb
@@ -3,6 +3,9 @@ var Analytical = {
   identify: function(id, options) {
     <%= raw(analytical.javascript_for.identify.gsub(/^/, " " * 4).strip) %>
   },
+  track: function(page) {
+    <%= raw(analytical.javascript_for.track.gsub(/^/, " " * 4).strip) %>
+  },
   event: function(name, options, callback) {
     <%= raw(analytical.javascript_for.event.gsub(/^/, " " * 4).strip) %>
   },

--- a/lib/analytical/modules/console.rb
+++ b/lib/analytical/modules/console.rb
@@ -30,7 +30,7 @@ module Analytical
         JS
       end
 
-      def track(*args) # event, properties, callback
+      def track(*args) # page
         <<-JS.gsub(/^ {10}/, '')
           if (typeof(console) !== 'undefined' && console != null) {
             console.log('Analytical track', arguments)

--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -26,6 +26,12 @@ module Analytical
         end
       end
 
+      def track(*args) # page
+        <<-JS.gsub(/^ {10}/, '')
+          ga('send', 'pageview', page);
+        JS
+      end
+
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
           ga('send', 'event', name, options && options.action || 'undefined', options && options.label, options && options.value);

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -58,13 +58,6 @@ module Analytical
         JS
       end
 
-      # def track(*args) # event, properties, callback
-      #   # event_name, properties, callback
-      #   <<-JS.gsub(/^ {10}/, '')
-      #     mixpanel.track(event, properties, callback);
-      #   JS
-      # end
-
       # Used to set "Super Properties" - http://mixpanel.com/api/docs/guides/super-properties
       def set(*args) # properties
         <<-JS.gsub(/^ {10}/, '')


### PR DESCRIPTION
The `track` option already makes part of analytical, but it was not being "outputted" (`app/views/application/_analytical_javascript.html.erb`).

It was configured to allow tracking of virtual pages (just a page view with the url specified) in the google module.
https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications