### PR TITLE
Enable identify option for google module

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -26,6 +26,14 @@ module Analytical
         end
       end
 
+      # note that "Session Unification" must be enabled in the GA User-ID feature
+      # because the page view event happens before the identify
+      def identify(*args) # id, options
+        <<-JS.gsub(/^ {10}/, '')
+          ga('set', 'userId', id);
+        JS
+      end
+
       def track(*args) # page
         <<-JS.gsub(/^ {10}/, '')
           ga('send', 'pageview', page);


### PR DESCRIPTION
More information:
- https://support.google.com/analytics/answer/3123663
- https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id
- https://support.google.com/analytics/answer/3123666

In some of the documentation about the User-ID feature the instructions are to pass the user id in the creation of the `ga` object. To do that when rendering the page, we would have to retrieve the user id from a cookie or any other option that doesn't have the user id in the page source, because of cached pages.

But during the configuration of the User-ID feature in the GA site the instructions were:
> **How to implement the User-ID in your tracking code**
> Google Analytics cannot generate, assign, or manage the unique IDs that are assigned as User-IDs. To use this feature, you must generate your own IDs and be able to consistently associate them with a set of data. In a typical scenario, these IDs can be generated through your authentication system, passed to an account at sign-in, and then sent to Google Analytics.
> Add the following line to your tracking code to send User-ID data to Google Analytics:
> `ga('set', 'userId', {{USER_ID}}); // Set the user ID using signed-in user_id.`
> Where the value of USER_ID is a string and represents the stable and unique ID retrieved from your system.

So this is implemented through the identify option of the analytical gem,

The only thing to consider is that the page view event happens with the initialisation and before the identify. But if we have the "Session Unification" enabled this is not a problem:
> Session unification allows hits collected before the User-ID is assigned to be associated with ID, so long as the hits are from the session in which an ID value is assigned for the first time. When OFF, only data with User-ID explicitly assigned can be associated. Learn more about session unification.
