### PR TITLE
Properly enable identify option for google module

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -19,19 +19,15 @@ module Analytical
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
             
             ga('create', '#{options[:key]}', 'auto');#{linkid}
+            var userId = document.cookie.replace(/(?:(?:^|.*;\s*)external_user_id\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+            if(userId.length > 0) {
+              ga('set', 'userId', userId);
+            }
             ga('send', 'pageview');
           </script>
           HTML
           js
         end
-      end
-
-      # note that "Session Unification" must be enabled in the GA User-ID feature
-      # because the page view event happens before the identify
-      def identify(*args) # id, options
-        <<-JS.gsub(/^ {10}/, '')
-          ga('set', 'userId', id);
-        JS
       end
 
       def track(*args) # page, options


### PR DESCRIPTION
Fix #11

This uses our `external_user_id` cookie.