### PR TITLE
Integrate GA and Optimizely

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -23,6 +23,11 @@ module Analytical
             if(userId.length > 0) {
               ga('set', 'userId', userId);
             }
+
+            // Optimizely Universal Analytics Integration Code
+            window.optimizely = window.optimizely || [];
+            window.optimizely.push("activateUniversalAnalytics");
+
             ga('send', 'pageview');
           </script>
           HTML


### PR DESCRIPTION
Integrate GA and Optimizely. Send data about an Optimizely experiment to GA so we can track things that Optimizely does not (e.g. time spent in page)