### PR TITLE
Track events in intercom

### DIFF
--- a/lib/analytical/modules/intercom.rb
+++ b/lib/analytical/modules/intercom.rb
@@ -1,0 +1,20 @@
+module Analytical
+  module Modules
+    class Intercom
+      include Analytical::Modules::Base
+
+      def initialize(options={})
+        super
+        @tracking_command_location = :body_append
+      end
+
+      # Intercom indentification is being done through the intercom-rails gem
+
+      def event(*args) # name, options, callback
+        <<-JS.gsub(/^ {10}/, '')
+          Intercom('trackEvent', name, options || {});
+        JS
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an Intercom module to analytical so that events can also be sent to Intercom. The identify step is not implemented since that is being taken care by the [intercom-rails gem](https://github.com/intercom/intercom-rails). 