### PR TITLE
Ga label update

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -43,7 +43,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-          ga('send', 'event', name, options && options.action || 'undefined', options && options.label, options && options.value);
+          ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), options && options.value);
         JS
       end
       


### PR DESCRIPTION
**The problem**
When an event gets sent to Google analytics all the properties (options) are lost since GA only supports sending a category, action, label and value argument along with the event.
https://developers.google.com/analytics/devguides/collection/analyticsjs/events 

**Proposed solution**
I suggest we stringify the properties and add them in the event label. This will allow us to differentiate events between each other by using a match regex filter.
http://stackoverflow.com/questions/25373015/google-analytics-event-tracking-with-multiple-labels

**Use case**
I want to set up a goal for first and repeat investment. I have no way to differentiate by the investment count property since it is not passed in GA.