### PR TITLE
Ignore referrer when cookie for that is present

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -19,6 +19,10 @@ module Analytical
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
             
             ga('create', '#{options[:key]}', 'auto');#{linkid}
+            var match = document.cookie.match(new RegExp('(^| )ignored_referrer=([^;]+)'));
+            if (match && decodeURIComponent(match[2]) === document.referrer) {
+              ga('set', 'referrer', window.location.origin);
+            }
             var userId = document.cookie.replace(/(?:(?:^|.*;\s*)external_user_id\s*\=\s*([^;]*).*$)|^.*$/, "$1");
             if(userId.length > 0) {
               ga('set', 'userId', userId);


### PR DESCRIPTION
The way to ignore the referrer is to set our own domain as the referrer.

Check the PR https://github.com/Seedrs/seedrs/pull/4127 for more information about this.

Solution based on https://medium.com/fatlama-nerds/excluding-facebook-and-google-social-sign-in-from-your-referrals-with-google-analytics-ff81588e519