### PR TITLE
(enhancement) Ensure a whole number is sent to GA

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -47,7 +47,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
+          ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
         JS
       end
       

--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -47,7 +47,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && typeof options.value === "number" || "string" &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
+            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
         JS
       end
       

--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -47,7 +47,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && typeof options.value === "number" || "string" && parseInt(options.value) != NaN && parseInt(options.value)) || 0);
+            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && typeof options.value === "number" || "string" &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
         JS
       end
       

--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -47,7 +47,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-          ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), options && options.value);
+            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), options && typeof options.value === "number" && parseInt(options.value));
         JS
       end
       

--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -47,7 +47,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), options && typeof options.value === "number" && parseInt(options.value));
+            ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && typeof options.value === "number" || "string" && parseInt(options.value) != NaN && parseInt(options.value)) || 0);
         JS
       end
       


### PR DESCRIPTION
According to googles docs https://developers.google.com/analytics/devguides/collection/analyticsjs/events#event_fields the `eventValue` property needs to be an interger 


```
options= { value: "abc" }
console.log((options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
//  0

options= { value: "123" }
console.log((options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
// 123

options= { value: 1.2}
console.log((options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
// 1

```