### PR TITLE
(improvement) Ensure GA hits are delivered even when page is being unloaded

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -27,6 +27,10 @@ module Analytical
             if(userId.length > 0) {
               ga('set', 'userId', userId);
             }
+            
+            // Ensure hits are delivered even when the network request is being sent and the page
+            // is being unloaded. This feature is only used when available.
+            ga('set', 'transport', 'beacon');
 
             // Optimizely Universal Analytics Integration Code
             window.optimizely = window.optimizely || [];


### PR DESCRIPTION
With this solution we don't have to add sleep calls nor create custom logic to handle GA callbacks and prevent forms from being submitted, etc. Do note that there are some browsers that don't support this today, e.g. IE. In those cases, we may lose hits if we don't do anything. Also note that it's very rare for us to send hits right before a page is unloaded.

I recommend the following read: https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits