### PR TITLE
(fix) GA events

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -51,7 +51,7 @@ module Analytical
 
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
-          ga('send', 'event', name, options && options.action || 'undefined', JSON.stringify(options), (options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
+          ga('send', 'event', options && options.action || 'undefined', JSON.stringify(options), (options && (typeof options.value === "number" || "string") &&  !isNaN(parseInt(options.value)) && parseInt(options.value)) || 0);
         JS
       end
       


### PR DESCRIPTION
When using Google analytics events with the layered architecture, it doesn't expect for a event name to be passed.

This gem was sending:
```
ga("send", "event", name, options)
```

While the documentation says it should be like this:
```
 ga('send', 'event', {
    eventCategory: 'Outbound Link',
    eventAction: 'click',
    eventLabel: event.target.href
  });
```

With the new structure we setup, the events in the platform are being sent like this:
![image](https://user-images.githubusercontent.com/11885775/93361376-b5cc1b00-f83c-11ea-8923-d71218a442d5.png)
