### PR TITLE
(fix) gtm event names

### DIFF
--- a/lib/analytical/modules/google_tag_manager.rb
+++ b/lib/analytical/modules/google_tag_manager.rb
@@ -28,10 +28,9 @@ module Analytical
       def event(*args) # name, options, callback
         <<-JS.gsub(/^ {10}/, '')
           var gtmVariables = {};
-          for (var k in options) {
-            gtmVariables[k] = options[k];
-          }
-          gtmVariables.event = name;
+          
+          gtmVariables.event = options['eventCategory'] + " " + options['eventAction'];
+
           gtmDataLayer.push(gtmVariables);
         JS
       end


### PR DESCRIPTION
GA and GTM are using the same method call to send the events.
Howerver `ga("send", "event", object)` can receive an object with multiple properties (eventCategory, eventAction, eventLabel, eventValue), and this same object is sent to the method that does `dataLayer.push({ event: name })`.

The name param is always empty, so the event can't be tracked in GTM. To fix this, I decided to concatenate eventCategory and eventAction from the options object to represent the event sent to GTM.

![image](https://user-images.githubusercontent.com/11885775/94288378-40a0ca00-ff4f-11ea-96de-43a22282c75c.png)
