### PR TITLE
(fix) missing data layer values

### DIFF
--- a/lib/analytical/modules/google_tag_manager.rb
+++ b/lib/analytical/modules/google_tag_manager.rb
@@ -30,6 +30,15 @@ module Analytical
           var gtmVariables = {};
           
           gtmVariables.event = options['eventCategory'] + " " + options['eventAction'];
+          
+          try {
+            var eventLabels = JSON.parse(options['eventLabel']);
+            for (var key in eventLabels){
+              gtmVariables[key] = eventLabels[key];
+            }
+          } catch(e) {
+            // We have event without labels and others that are just strings
+          }
 
           gtmDataLayer.push(gtmVariables);
         JS


### PR DESCRIPTION
Ran the following in the browser to test it:
```
var options = { eventCategory: 'Investments', eventAction: 'Confirmed', eventLabel: "{\"campaign-id\":28747,\"campaign_name\":\"Mazzanti Automobili\",\"campaign_type\":\"equity\",\"campaign_categories\":\"Travel, Leisure \u0026 Sport, Mixed Digital/Non-Digital, Mixed B2B/B2C\",\"see_campaign_investment_details\":true,\"see_details\":true}" }

var gtmVariables = {};

gtmVariables.event = options['eventCategory'] + " " + options['eventAction'];

var eventLabels = JSON.parse(options.eventLabel)
for (var k in options) {
  gtmVariables[k] = options[k];
}
```

Tested the following cases when parsing eventLabels:
<img width="732" alt="Screenshot 2020-09-29 at 10 58 05" src="https://user-images.githubusercontent.com/11885775/94544372-0f701480-0243-11eb-9b68-82c59a6486db.png">
<img width="936" alt="Screenshot 2020-09-29 at 10 57 58" src="https://user-images.githubusercontent.com/11885775/94544379-126b0500-0243-11eb-99a3-0612a526f35b.png">
<img width="1031" alt="Screenshot 2020-09-29 at 10 57 49" src="https://user-images.githubusercontent.com/11885775/94544382-13039b80-0243-11eb-9e86-c443485c10e6.png">
<img width="1164" alt="Screenshot 2020-09-29 at 10 59 13" src="https://user-images.githubusercontent.com/11885775/94544384-139c3200-0243-11eb-98b5-29dee8241068.png">
