### PR TITLE
(improvement) Implement integration between GMT and GA

### DIFF
--- a/lib/analytical/modules/google_tag_manager.rb
+++ b/lib/analytical/modules/google_tag_manager.rb
@@ -29,7 +29,9 @@ module Analytical
         <<-JS.gsub(/^ {10}/, '')
           var gtmVariables = {};
           
-          gtmVariables.event = options['eventCategory'] + " " + options['eventAction'];
+          gtmVariables.event = "Integration GA-GTM Event";
+          gtmVariables['eventCategory'] = options['eventCategory'];
+          gtmVariables['eventAction'] = options['eventAction'];
           
           try {
             var eventLabels = JSON.parse(options['eventLabel']);
@@ -44,5 +46,17 @@ module Analytical
         JS
       end
     end
+
+    def track(*args) # name, options, callback
+      <<-JS.gsub(/^ {10}/, '')
+        var gtmVariables = {};
+        
+        gtmVariables.event = "Integration GA-GTM Track";
+        gtmVariables['customTrackPageUrl'] = page;
+        
+        gtmDataLayer.push(gtmVariables);
+      JS
+    end
+  end
   end
 end


### PR DESCRIPTION
## What does this PR do?

This PR changes the way events are sent to GTM.

All the events that go to GTM from analytical will have the value "Integration GA-GTM Event". A similar strategy is followed for tracking virtual pageviews. 

This is part of a wider re-architecture re-org around Seedrs Analytics. More information can be found here: https://docs.google.com/presentation/d/19gfpiicdeX4HGUx2QBLSEVUHk1ND5q6AyE_SY6_0hgY/edit#slide=id.g3baa1d7c31_0_215

## How should this be manually tested?

This should be tested using the Platform. You will need to point your Gemfile to this commit. 
Look for this line in the Gemfile of the Platform: gem "analytical"

## Any background context you want to provide?

Our current architecture is loading 2 GA trackers.

## External context (JIRA, Figma, etc)

https://seedrs.atlassian.net/browse/CTO-665

## Deploy plan

This can be merged and then the Platform will have another PR to include this work, by modifying the Gemfile.